### PR TITLE
Local configuration, multi-repo support for contributor update tool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ These features will be included in the next release:
 
 Added
 -----
+- Multiple repositories can now be specified in a separate configuration section in
+  ``contributors.yaml``.
+- Contribution search links now point to the `/search` page on GitHub and support
+  searching multiple repositories.
 
 Fixed
 -----


### PR DESCRIPTION
Allow GitHub repositories to configure which repository/repositories to search in for contributions.

Example `contributors.yaml`:
```yaml
---
repositories:
  - akaihola/darkgraylib
  - akaihola/darker
---
username1:
  - {link_type: issues, type: Bug reports}
```