### PR TITLE
Remove `darkgray-verify-contributors`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dynamic = ["version", "description"]
 dependencies = [
     "airium>=0.2.3",
     "click>=8.0.0",
-    "defusedxml>=0.7.1",
     "pyproject-parser",
     "requests_cache>=0.7",
     "ruamel.yaml>=0.15.78",
@@ -21,7 +20,6 @@ Home = "https://github.com/akaihola/darkgray-dev-tools"
 
 [project.scripts]
 darkgray_bump_version = "darkgray_dev_tools.darkgray_bump_version:bump_version"
-darkgray_verify_contributors = "darkgray_dev_tools.darkgray_update_contributors:verify"
 darkgray_update_contributors = "darkgray_dev_tools.darkgray_update_contributors:update"
 
 [tool.black]

--- a/src/darkgray_dev_tools/exceptions.py
+++ b/src/darkgray_dev_tools/exceptions.py
@@ -23,42 +23,6 @@ class NoMatchError(Exception):
         super().__init__(f"Can't find `{regex}` in `{path}`")
 
 
-class SectionNotFoundError(Exception):
-    """Raised if an expected text section can't be found in a text file."""
-
-    def __init__(self, section: str, filename: str) -> None:
-        """Initialize the exception.
-
-        :param section: The name of the section which was not found.
-        :param filename: The name of the file in which the section couldn't be found
-
-        """
-        super().__init__(f"No {section} could be found in `{filename}`")
-
-
-class WrongContributionTypeError(Exception):
-    """Raised if verification finds a mismatching URL and contribution type."""
-
-    def __init__(
-        self,
-        url: str,
-        contribution_type: str,
-        valid_contribution_types: tuple[str, ...],
-    ) -> None:
-        """Initialize the exception.
-
-        :param url: The link to a GitHub search
-        :param contribution_type: The type of contribution to be found in search results
-        :param valid_contribution_types: Contribution types which can appear in the
-                                         search results
-
-        """
-        super().__init__(
-            f"Contribution type for {url} was {contribution_type}, "
-            f"expected {valid_contribution_types}"
-        )
-
-
 class GitHubRepoNameError(Exception):
     """Raised if ``git remote get-url`` fails & repository name can't be determined."""
 
@@ -72,18 +36,6 @@ class GitHubRepoNameError(Exception):
             f"Could not run Git to determine the name of the GitHub repository for "
             f"the working directory in {cwd}"
         )
-
-
-class InvalidGitHubUrlError(Exception):
-    """Raised if a contribution link doesn't point to GitHub."""
-
-    def __init__(self, url: str) -> None:
-        """Initialize the exception.
-
-        :param url: A link to search results for contributions of a contributor
-
-        """
-        super().__init__(f"{url} is not a valid GitHub URL")
 
 
 class GitHubApiNotFoundError(Exception):


### PR DESCRIPTION
Now that the contributors table and the contributors document are always programmatically generated, we no longer have a need to verify that the hand-written table matches the YAML source.