### PR TITLE
Configure Pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
+addopts =
+  --doctest-modules
+  --durations 10
+  --show-capture no


### PR DESCRIPTION
- run all doctests
- normalize whitespace in doctests
- ignore exception details in doctests
- show durations of slowest tests
- don't show captured output