### PR TITLE
Update Airium for compatibility w/ Pip >= 24.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Added
 
 Fixed
 -----
+- Upgrade Airium for compatibility with recent Pip versions.
 
 
 0.1.0_ - 2024-04-21

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "darkgray_dev_tools"
 authors = [{name = "Antti Kaihola", email = "13725+akaihola@users.noreply.github.com"}]
 dynamic = ["version", "description"]
 dependencies = [
-    "airium>=0.2.3",
+    "airium>=0.2.6",
     "click>=8.0.0",
     "pyproject-parser",
     "requests_cache>=0.7",


### PR DESCRIPTION
Airium 0.2.3 to 0.2.5 wheel metadata isn't supported by Pip >= 24.1. Airium 0.2.6 fixes the metadata.